### PR TITLE
代码仓库添加 .gitignore 文件以忽略上传 node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store


### PR DESCRIPTION
问题：原仓库上传了一次 node_modules 文件夹，目前 git 记录里还有这部分文件，导致 git clone 时间**特别特别久**，只能指定 --depth=1 。
建议：把这个pr合并之后，在git里运行一次 git rm -r --cached node_modules 再提交一次代码